### PR TITLE
Fix issue #7 - allow empty string to mean no prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -825,7 +825,11 @@ Object.defineProperty(Prompt.prototype, 'prefix', {
     this.question.prefix = prefix;
   },
   get: function() {
-    return this.question.prefix || (log.cyan('?') + ' ');
+    if (typeof this.question.prefix === 'undefined') {
+      return log.cyan('?') + ' ';
+    } else {
+      return this.question.prefix;
+    }
   }
 });
 


### PR DESCRIPTION
As @stevenvachon guessed in issue #7, there was a truthy test for `prefix`, which meant that you could not supply an empty string to get it to render with no prefix.

This change uses an undefined test instead, so you can now set:

```js
prompt.prefix = '';
```

and get something like this:

```
What is your favorite color? (red)
```